### PR TITLE
Fix admin order creation

### DIFF
--- a/app/models/shoppe/order.rb
+++ b/app/models/shoppe/order.rb
@@ -13,7 +13,7 @@ module Shoppe
     require_dependency 'shoppe/order/delivery'
     
     # All items which make up this order
-    has_many :order_items, :dependent => :destroy, :class_name => 'Shoppe::OrderItem'
+    has_many :order_items, :dependent => :destroy, :class_name => 'Shoppe::OrderItem', inverse_of: :order
     accepts_nested_attributes_for :order_items, :allow_destroy => true, :reject_if => Proc.new { |a| a['ordered_item_id'].blank? }
 
     # All products which are part of this order (accessed through the items)

--- a/app/models/shoppe/order_item.rb
+++ b/app/models/shoppe/order_item.rb
@@ -6,7 +6,7 @@ module Shoppe
     # The associated order
     #
     # @return [Shoppe::Order]
-    belongs_to :order, :class_name => 'Shoppe::Order', :touch => true
+    belongs_to :order, :class_name => 'Shoppe::Order', :touch => true, inverse_of: :order_items
 
     # The item which has been ordered
     belongs_to :ordered_item, :polymorphic => true

--- a/app/models/shoppe/order_item.rb
+++ b/app/models/shoppe/order_item.rb
@@ -20,7 +20,7 @@ module Shoppe
 
     validate do
       unless in_stock?
-        errors.add :quantity, :too_hight_quantity
+        errors.add :quantity, :too_high_quantity
       end
     end
 


### PR DESCRIPTION
Without inverse_of, accepts_nested_attributes_for order_items never sets the order_id, which breaks the UI when it tries to set the tax rate.