### PR TITLE
Add tax inclusive field to products

### DIFF
--- a/app/assets/javascripts/shoppe/products.coffee
+++ b/app/assets/javascripts/shoppe/products.coffee
@@ -1,0 +1,25 @@
+$ ->
+
+  #
+  # Refresh the order
+  #
+  calculateTax = (form, invokeField)->
+    if $('select#product_tax_rate_id', form).val().length > 0
+      $('input#product_price_including_tax', form).prop('disabled', false)
+    else
+      $('input#product_price_including_tax', form).prop('disabled', true)
+      $('input#product_price_including_tax', form).val($('input#product_price', form).val())
+
+  #
+  # Setup the product form to calculate tax
+  #
+  setupProductForm = (form)->
+    # All select boxes should use Chosen
+    $('select#product_tax_rate_id', form).on 'change', -> calculateTax $(this).parents('form'), $(this).attr('id')
+    calculateTax form, null
+  
+  # 
+  # Automatically set up the form on page load if one exists.
+  #
+  if $('form.productForm').length
+    setupProductForm $('form.productForm')

--- a/app/assets/javascripts/shoppe/products.coffee
+++ b/app/assets/javascripts/shoppe/products.coffee
@@ -21,5 +21,5 @@ $ ->
   # 
   # Automatically set up the form on page load if one exists.
   #
-  if $('form.productForm').length
+  if $('select#product_tax_rate_id').length
     setupProductForm $('form.productForm')

--- a/app/assets/stylesheets/shoppe/application.scss
+++ b/app/assets/stylesheets/shoppe/application.scss
@@ -151,8 +151,12 @@ header.main {
 	form {
 		fieldset {
 
-			.splitContainer { margin:0 25px; margin-bottom:15px; height:50px;}
-			.splitContainer:last-child { margin-bottom:0;}
+			.splitContainer { 
+				margin:0 25px; 
+				margin-bottom:25px; 
+				height:50px;
+				&:last-child { margin-bottom:0;}
+			}
 
 			dl {
 				margin:0 25px;
@@ -500,7 +504,7 @@ div.field_with_errors { display:inline;}
 div.moneyInput {
 	overflow:hidden;
 	div.currency {float:left; background:#f3f6ec; color:#74884a; padding:5px; width:20px; text-align:center;border:1px solid #c5ceb1; font-size:1.1em; border-right:0;}
-	input {  width:100px; font-size:1.1em;}
+	input { width:75%; font-size:1.1em;}
 }
 
 //

--- a/app/controllers/shoppe/products_controller.rb
+++ b/app/controllers/shoppe/products_controller.rb
@@ -51,7 +51,7 @@ module Shoppe
     private
 
     def safe_params
-      params[:product].permit(:product_category_id, :name, :sku, :permalink, :description, :short_description, :weight, :price, :cost_price, :tax_rate_id, :stock_control, :default_image_file, :data_sheet_file, :active, :featured, :in_the_box, :product_attributes_array => [:key, :value, :searchable, :public])
+      params[:product].permit(:product_category_id, :name, :sku, :permalink, :description, :short_description, :weight, :price, :price_including_tax, :cost_price, :tax_rate_id, :stock_control, :default_image_file, :data_sheet_file, :active, :featured, :in_the_box, :product_attributes_array => [:key, :value, :searchable, :public])
     end
 
   end

--- a/app/controllers/shoppe/variants_controller.rb
+++ b/app/controllers/shoppe/variants_controller.rb
@@ -43,7 +43,7 @@ module Shoppe
     private
 
     def safe_params
-      params[:product].permit(:name, :permalink, :sku, :default_image_file, :price, :cost_price, :tax_rate_id, :weight, :stock_control, :active, :default)
+      params[:product].permit(:name, :permalink, :sku, :default_image_file, :price, :price_including_tax, :cost_price, :tax_rate_id, :weight, :stock_control, :active, :default)
     end
 
   end

--- a/app/models/shoppe/order/billing.rb
+++ b/app/models/shoppe/order/billing.rb
@@ -46,7 +46,7 @@ module Shoppe
     #
     # @return [BigDecimal]
     def items_sub_total
-      order_items.inject(BigDecimal(0)) { |t, i| t + i.sub_total }
+      order_items.inject(BigDecimal(0)) { |t, i| t + i.sub_total }.round(2)
     end
 
     # The total price of the order before tax
@@ -61,7 +61,7 @@ module Shoppe
     # @return [BigDecimal]
     def tax
       self.delivery_tax_amount +
-      order_items.inject(BigDecimal(0)) { |t, i| t + i.tax_amount }
+      order_items.inject(BigDecimal(0)) { |t, i| t + i.tax_amount }.round(2)
     end
 
     # The total of the order including tax
@@ -70,7 +70,7 @@ module Shoppe
     def total
       self.delivery_price +
       self.delivery_tax_amount +
-      order_items.inject(BigDecimal(0)) { |t, i| t + i.total }
+      order_items.inject(BigDecimal(0)) { |t, i| t + i.total }.round(2)
     end
 
     # The total amount due on the order

--- a/app/views/shoppe/products/_form.html.haml
+++ b/app/views/shoppe/products/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @product, :html => {:multipart => true} do |f|
+= form_for @product, :html => {:multipart => true, :class => 'productForm'} do |f|
   = f.error_messages
   = field_set_tag  t('shoppe.products.product_information') do
     %dl
@@ -69,6 +69,9 @@
 
   - unless @product.has_variants?
     = field_set_tag t('shoppe.products.pricing') do
+      %dl
+        %dt= f.label :tax_rate_id, t('shoppe.products.tax_rate')
+        %dd= f.collection_select :tax_rate_id, Shoppe::TaxRate.ordered, :id, :description, {:include_blank => true}, {:class => 'chosen-with-deselect', :data => {:placeholder => t('shoppe.products.no_tax')}}
       .splitContainer
         %dl.third
           %dt= f.label :price, t('shoppe.products.price')
@@ -77,15 +80,17 @@
               .currency= Shoppe.settings.currency_unit.html_safe
               = f.text_field :price, :class => 'text'
         %dl.third
+          %dt= f.label :price_including_tax, t('shoppe.products.price_including_tax', tax_name: Shoppe.settings.tax_name)
+          %dd
+            .moneyInput
+              .currency= Shoppe.settings.currency_unit.html_safe
+              = f.text_field :price_including_tax, :class => 'text'
+        %dl.third
           %dt= f.label :cost_price, t('shoppe.products.cost_price')
           %dd
             .moneyInput
               .currency= Shoppe.settings.currency_unit.html_safe
               = f.text_field :cost_price, :class => 'text'
-        %dl.third
-          %dt= f.label :tax_rate_id, t('shoppe.products.tax_rate')
-          %dd= f.collection_select :tax_rate_id, Shoppe::TaxRate.ordered, :id, :description, {:include_blank => true}, {:class => 'chosen-with-deselect', :data => {:placeholder => t('shoppe.products.no_tax')}}
-
     = field_set_tag  t('shoppe.products.stock_control') do
       .splitContainer
         %dl.half

--- a/app/views/shoppe/variants/form.html.haml
+++ b/app/views/shoppe/variants/form.html.haml
@@ -3,7 +3,7 @@
   %p.buttons= link_to t('shoppe.variants.back_to_variants'), [@product, :variants], :class => 'button'
   %h2.products= t('shoppe.variants.variants_of', product:@product.name)
 
-= form_for [@product, @variant], :url => @variant.new_record? ? product_variants_path(@product) : product_variant_path(@product, @variant), :html => {:multipart => true} do |f|
+= form_for [@product, @variant], :url => @variant.new_record? ? product_variants_path(@product) : product_variant_path(@product, @variant), :html => {:multipart => true, :class => 'productForm'} do |f|
   = f.error_messages
   = field_set_tag t('shoppe.variants.product_information') do
     .splitContainer
@@ -23,17 +23,28 @@
         = attachment_preview @variant.default_image, :hide_if_blank => true
         %p= f.file_field :default_image_file
   = field_set_tag t("shoppe.variants.pricing") do
+    %dl
+      %dt= f.label :tax_rate_id, t('shoppe.products.tax_rate')
+      %dd= f.collection_select :tax_rate_id, Shoppe::TaxRate.ordered, :id, :description, {:include_blank => true}, {:class => 'chosen-with-deselect', :data => {:placeholder => t('shoppe.variants.no_tax')}}
     .splitContainer
       %dl.third
-        %dt= f.label :price, t('shoppe.variants.price')
-        %dd= f.text_field :price, :class => 'text'
+        %dt= f.label :price, t('shoppe.products.price')
+        %dd
+          .moneyInput
+            .currency= Shoppe.settings.currency_unit.html_safe
+            = f.text_field :price, :class => 'text'
       %dl.third
-        %dt= f.label :cost_price, t('shoppe.variants.cost_price')
-        %dd= f.text_field :cost_price, :class => 'text'
+        %dt= f.label :price_including_tax, t('shoppe.products.price_including_tax', tax_name: Shoppe.settings.tax_name)
+        %dd
+          .moneyInput
+            .currency= Shoppe.settings.currency_unit.html_safe
+            = f.text_field :price_including_tax, :class => 'text'
       %dl.third
-        %dt= f.label :tax_rate_id, t('shoppe.variants.tax_rate')
-        %dd= f.collection_select :tax_rate_id, Shoppe::TaxRate.ordered, :id, :description, {:include_blank => true}, {:class => 'chosen-with-deselect', :data => {:placeholder => t('shoppe.variants.no_tax')}}
-
+        %dt= f.label :cost_price, t('shoppe.products.cost_price')
+        %dd
+          .moneyInput
+            .currency= Shoppe.settings.currency_unit.html_safe
+            = f.text_field :cost_price, :class => 'text'
   = field_set_tag t('shoppe.variants.stock_control') do
     .splitContainer
       %dl.half

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -424,7 +424,8 @@ en:
       on_sale?: On sale?
       on_sale_info:  If checked, this product will be displayed within the public store
       permalink: Permalink
-      price: Price
+      price: Sale Price
+      price_including_tax: Including %{tax_name}
       price_variants: Price/Variants
       pricing: Pricing
       product_category: Product category

--- a/db/migrate/20141103003428_increase_money_precision.rb
+++ b/db/migrate/20141103003428_increase_money_precision.rb
@@ -1,0 +1,8 @@
+class IncreaseMoneyPrecision < ActiveRecord::Migration
+  def change
+    change_column :shoppe_products, :price, :decimal, precision: 12, scale: 6
+    change_column :shoppe_delivery_service_prices, :price, :decimal, precision: 12, scale: 6
+    change_column :shoppe_order_items, :unit_price, :decimal, precision: 12, scale: 6
+    change_column :shoppe_orders, :delivery_price, :decimal, precision: 12, scale: 6
+  end
+end

--- a/test/app/db/schema.rb
+++ b/test/app/db/schema.rb
@@ -178,48 +178,34 @@ ActiveRecord::Schema.define(version: 20141103003428) do
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "parent_id"
-    t.integer  "lft"
-    t.integer  "rgt"
-    t.integer  "depth"
-    t.string   "ancestral_permalink"
-    t.boolean  "permalink_includes_ancestors", default: false
   end
 
-  add_index "shoppe_product_categories", ["lft"], name: "index_shoppe_product_categories_on_lft", using: :btree
   add_index "shoppe_product_categories", ["permalink"], name: "index_shoppe_product_categories_on_permalink", using: :btree
-  add_index "shoppe_product_categories", ["rgt"], name: "index_shoppe_product_categories_on_rgt", using: :btree
-
-  create_table "shoppe_product_categorizations", force: true do |t|
-    t.integer "product_id",          null: false
-    t.integer "product_category_id", null: false
-  end
-
-  add_index "shoppe_product_categorizations", ["product_category_id"], name: "categorization_by_product_category_id", using: :btree
-  add_index "shoppe_product_categorizations", ["product_id"], name: "categorization_by_product_id", using: :btree
 
   create_table "shoppe_products", force: true do |t|
     t.integer  "parent_id"
+    t.integer  "product_category_id"
     t.string   "name"
     t.string   "sku"
     t.string   "permalink"
     t.text     "description"
     t.text     "short_description"
-    t.boolean  "active",                                     default: true
-    t.decimal  "weight",            precision: 8,  scale: 3, default: 0.0
-    t.decimal  "price",             precision: 12, scale: 6, default: 0.0
-    t.decimal  "cost_price",        precision: 8,  scale: 2, default: 0.0
+    t.boolean  "active",                                       default: true
+    t.decimal  "weight",              precision: 8,  scale: 3, default: 0.0
+    t.decimal  "price",               precision: 12, scale: 6, default: 0.0
+    t.decimal  "cost_price",          precision: 8,  scale: 2, default: 0.0
     t.integer  "tax_rate_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "featured",                                   default: false
+    t.boolean  "featured",                                     default: false
     t.text     "in_the_box"
-    t.boolean  "stock_control",                              default: true
-    t.boolean  "default",                                    default: false
+    t.boolean  "stock_control",                                default: true
+    t.boolean  "default",                                      default: false
   end
 
   add_index "shoppe_products", ["parent_id"], name: "index_shoppe_products_on_parent_id", using: :btree
   add_index "shoppe_products", ["permalink"], name: "index_shoppe_products_on_permalink", using: :btree
+  add_index "shoppe_products", ["product_category_id"], name: "index_shoppe_products_on_product_category_id", using: :btree
   add_index "shoppe_products", ["sku"], name: "index_shoppe_products_on_sku", using: :btree
 
   create_table "shoppe_settings", force: true do |t|

--- a/test/app/db/schema.rb
+++ b/test/app/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141026181716) do
+ActiveRecord::Schema.define(version: 20141103003428) do
 
   create_table "nifty_attachments", force: true do |t|
     t.integer  "parent_id"
@@ -47,11 +47,11 @@ ActiveRecord::Schema.define(version: 20141026181716) do
   create_table "shoppe_delivery_service_prices", force: true do |t|
     t.integer  "delivery_service_id"
     t.string   "code"
-    t.decimal  "price",               precision: 8, scale: 2
-    t.decimal  "cost_price",          precision: 8, scale: 2
+    t.decimal  "price",               precision: 12, scale: 6
+    t.decimal  "cost_price",          precision: 8,  scale: 2
     t.integer  "tax_rate_id"
-    t.decimal  "min_weight",          precision: 8, scale: 2
-    t.decimal  "max_weight",          precision: 8, scale: 2
+    t.decimal  "min_weight",          precision: 8,  scale: 2
+    t.decimal  "max_weight",          precision: 8,  scale: 2
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "country_ids"
@@ -79,12 +79,12 @@ ActiveRecord::Schema.define(version: 20141026181716) do
     t.integer  "order_id"
     t.integer  "ordered_item_id"
     t.string   "ordered_item_type"
-    t.integer  "quantity",                                  default: 1
-    t.decimal  "unit_price",        precision: 8, scale: 2
-    t.decimal  "unit_cost_price",   precision: 8, scale: 2
-    t.decimal  "tax_amount",        precision: 8, scale: 2
-    t.decimal  "tax_rate",          precision: 8, scale: 2
-    t.decimal  "weight",            precision: 8, scale: 3
+    t.integer  "quantity",                                   default: 1
+    t.decimal  "unit_price",        precision: 12, scale: 6
+    t.decimal  "unit_cost_price",   precision: 8,  scale: 2
+    t.decimal  "tax_amount",        precision: 8,  scale: 2
+    t.decimal  "tax_rate",          precision: 8,  scale: 2
+    t.decimal  "weight",            precision: 8,  scale: 3
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -112,10 +112,10 @@ ActiveRecord::Schema.define(version: 20141026181716) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "delivery_service_id"
-    t.decimal  "delivery_price",            precision: 8, scale: 2
-    t.decimal  "delivery_cost_price",       precision: 8, scale: 2
-    t.decimal  "delivery_tax_rate",         precision: 8, scale: 2
-    t.decimal  "delivery_tax_amount",       precision: 8, scale: 2
+    t.decimal  "delivery_price",            precision: 12, scale: 6
+    t.decimal  "delivery_cost_price",       precision: 8,  scale: 2
+    t.decimal  "delivery_tax_rate",         precision: 8,  scale: 2
+    t.decimal  "delivery_tax_amount",       precision: 8,  scale: 2
     t.integer  "accepted_by"
     t.integer  "shipped_by"
     t.string   "consignment_number"
@@ -123,7 +123,7 @@ ActiveRecord::Schema.define(version: 20141026181716) do
     t.integer  "rejected_by"
     t.string   "ip_address"
     t.text     "notes"
-    t.boolean  "separate_delivery_address",                         default: false
+    t.boolean  "separate_delivery_address",                          default: false
     t.string   "delivery_name"
     t.string   "delivery_address1"
     t.string   "delivery_address2"
@@ -131,8 +131,8 @@ ActiveRecord::Schema.define(version: 20141026181716) do
     t.string   "delivery_address4"
     t.string   "delivery_postcode"
     t.integer  "delivery_country_id"
-    t.decimal  "amount_paid",               precision: 8, scale: 2, default: 0.0
-    t.boolean  "exported",                                          default: false
+    t.decimal  "amount_paid",               precision: 8,  scale: 2, default: 0.0
+    t.boolean  "exported",                                           default: false
     t.string   "invoice_number"
   end
 
@@ -178,34 +178,48 @@ ActiveRecord::Schema.define(version: 20141026181716) do
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "parent_id"
+    t.integer  "lft"
+    t.integer  "rgt"
+    t.integer  "depth"
+    t.string   "ancestral_permalink"
+    t.boolean  "permalink_includes_ancestors", default: false
   end
 
+  add_index "shoppe_product_categories", ["lft"], name: "index_shoppe_product_categories_on_lft", using: :btree
   add_index "shoppe_product_categories", ["permalink"], name: "index_shoppe_product_categories_on_permalink", using: :btree
+  add_index "shoppe_product_categories", ["rgt"], name: "index_shoppe_product_categories_on_rgt", using: :btree
+
+  create_table "shoppe_product_categorizations", force: true do |t|
+    t.integer "product_id",          null: false
+    t.integer "product_category_id", null: false
+  end
+
+  add_index "shoppe_product_categorizations", ["product_category_id"], name: "categorization_by_product_category_id", using: :btree
+  add_index "shoppe_product_categorizations", ["product_id"], name: "categorization_by_product_id", using: :btree
 
   create_table "shoppe_products", force: true do |t|
     t.integer  "parent_id"
-    t.integer  "product_category_id"
     t.string   "name"
     t.string   "sku"
     t.string   "permalink"
     t.text     "description"
     t.text     "short_description"
-    t.boolean  "active",                                      default: true
-    t.decimal  "weight",              precision: 8, scale: 3, default: 0.0
-    t.decimal  "price",               precision: 8, scale: 2, default: 0.0
-    t.decimal  "cost_price",          precision: 8, scale: 2, default: 0.0
+    t.boolean  "active",                                     default: true
+    t.decimal  "weight",            precision: 8,  scale: 3, default: 0.0
+    t.decimal  "price",             precision: 12, scale: 6, default: 0.0
+    t.decimal  "cost_price",        precision: 8,  scale: 2, default: 0.0
     t.integer  "tax_rate_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "featured",                                    default: false
+    t.boolean  "featured",                                   default: false
     t.text     "in_the_box"
-    t.boolean  "stock_control",                               default: true
-    t.boolean  "default",                                     default: false
+    t.boolean  "stock_control",                              default: true
+    t.boolean  "default",                                    default: false
   end
 
   add_index "shoppe_products", ["parent_id"], name: "index_shoppe_products_on_parent_id", using: :btree
   add_index "shoppe_products", ["permalink"], name: "index_shoppe_products_on_permalink", using: :btree
-  add_index "shoppe_products", ["product_category_id"], name: "index_shoppe_products_on_product_category_id", using: :btree
   add_index "shoppe_products", ["sku"], name: "index_shoppe_products_on_sku", using: :btree
 
   create_table "shoppe_settings", force: true do |t|


### PR DESCRIPTION
Another requirement from my clients – add their products to the system with tax already included.  

Here's what it looks like (the GST in the screenshot comes from the name of the tax in settings):

![price-tax-included](https://cloud.githubusercontent.com/assets/749593/4878422/93ddee14-630b-11e4-96d6-9701031e4a90.png)

As always, there's room for improvement (e.g. introducing AJAX to calculate the value "on the fly" without submitting the form, refactoring this out to be a concern on the model so it can be applied to other models as well), but it's a start.

Also I won't be offended if you guys decide this shouldn't be in the main repo as it stands.  But here for discussion.