### PR TITLE
Localisations / Translations

### DIFF
--- a/app/controllers/shoppe/product_category_localisations_controller.rb
+++ b/app/controllers/shoppe/product_category_localisations_controller.rb
@@ -1,0 +1,58 @@
+require "globalize"
+
+module Shoppe
+  class ProductCategoryLocalisationsController < ApplicationController
+
+    before_filter { @active_nav = :product_categories }
+    before_filter { @product_category = Shoppe::ProductCategory.find(params[:product_category_id]) }
+    before_filter { params[:id] && @localisation = @product_category.translations.find(params[:id]) }
+
+    def index
+      @localisations = @product_category.translations
+    end
+
+    def new
+      @localisation = @product_category.translations.new
+      render :action => "form"
+    end
+
+    def create
+      if I18n.available_locales.include? safe_params[:locale].to_sym
+        I18n.locale = safe_params[:locale].to_sym
+
+        if @product_category.update(safe_params)
+          I18n.locale = I18n.default_locale
+          redirect_to [@product_category, :localisations], :flash => { :notice => t("shoppe.localisations.localisation_created") }
+        else
+          render :action => "edit"
+        end
+      else
+        redirect_to [@product_category, :localisations]
+      end
+    end
+
+    def edit
+      render :action => "form"
+    end
+
+    def update
+      if @localisation.update(safe_params)
+        redirect_to [@product_category, :localisations], :notice => t('shoppe.localisations.localisation_updated')
+      else
+        render :action => "form"
+      end
+    end
+
+    def destroy
+      @localisation.destroy
+      redirect_to [@product_category, :localisations], :notice =>  t('shoppe.localisations.localisation_destroyed')
+    end
+
+    private
+
+    def safe_params
+      params[:product_category_translation].permit(:name, :locale, :permalink, :description)
+    end
+
+  end
+end

--- a/app/controllers/shoppe/product_localisations_controller.rb
+++ b/app/controllers/shoppe/product_localisations_controller.rb
@@ -3,7 +3,7 @@ require "globalize"
 module Shoppe
   class ProductLocalisationsController < ApplicationController
 
-    before_filter { @active_nav = :product_categories }
+    before_filter { @active_nav = :products }
     before_filter { @product = Shoppe::Product.find(params[:product_id]) }
     before_filter { params[:id] && @localisation = @product.translations.find(params[:id]) }
 

--- a/app/controllers/shoppe/product_localisations_controller.rb
+++ b/app/controllers/shoppe/product_localisations_controller.rb
@@ -24,7 +24,7 @@ module Shoppe
           I18n.locale = I18n.default_locale
           redirect_to [@product, :localisations], :flash => { :notice => t("shoppe.localisations.localisation_created") }
         else
-          render :action => "edit"
+          render :action => "form"
         end
       else
         redirect_to [@product, :localisations]

--- a/app/controllers/shoppe/product_localisations_controller.rb
+++ b/app/controllers/shoppe/product_localisations_controller.rb
@@ -1,0 +1,58 @@
+require "globalize"
+
+module Shoppe
+  class ProductLocalisationsController < ApplicationController
+
+    before_filter { @active_nav = :product_categories }
+    before_filter { @product = Shoppe::Product.find(params[:product_id]) }
+    before_filter { params[:id] && @localisation = @product.translations.find(params[:id]) }
+
+    def index
+      @localisations = @product.translations
+    end
+
+    def new
+      @localisation = @product.translations.new
+      render :action => "form"
+    end
+
+    def create
+      if I18n.available_locales.include? safe_params[:locale].to_sym
+        I18n.locale = safe_params[:locale].to_sym
+
+        if @product.update(safe_params)
+          I18n.locale = I18n.default_locale
+          redirect_to [@product, :localisations], :flash => { :notice => t("shoppe.localisations.localisation_created") }
+        else
+          render :action => "edit"
+        end
+      else
+        redirect_to [@product, :localisations]
+      end
+    end
+
+    def edit
+      render :action => "form"
+    end
+
+    def update
+      if @localisation.update(safe_params)
+        redirect_to [@product, :localisations], :notice => t('shoppe.localisations.localisation_updated')
+      else
+        render :action => "form"
+      end
+    end
+
+    def destroy
+      @localisation.destroy
+      redirect_to [@product, :localisations], :notice =>  t('shoppe.localisations.localisation_destroyed')
+    end
+
+    private
+
+    def safe_params
+      params[:product_translation].permit(:name, :locale, :permalink, :description, :short_description)
+    end
+
+  end
+end

--- a/app/controllers/shoppe/products_controller.rb
+++ b/app/controllers/shoppe/products_controller.rb
@@ -5,7 +5,7 @@ module Shoppe
     before_filter { params[:id] && @product = Shoppe::Product.root.find(params[:id]) }
 
     def index
-      @products = Shoppe::Product.root.includes(:stock_level_adjustments, :default_image, :product_categories, :variants).order(:name).group_by(&:product_category).sort_by { |cat,pro| cat.name }
+      @products = Shoppe::Product.root.includes(:translations, :stock_level_adjustments, :default_image, :product_categories, :variants).order(:name).group_by(&:product_category).sort_by { |cat,pro| cat.name }
     end
 
     def new

--- a/app/models/shoppe/product.rb
+++ b/app/models/shoppe/product.rb
@@ -1,4 +1,5 @@
-require 'roo'
+require "roo"
+require "globalize"
 
 module Shoppe
   class Product < ActiveRecord::Base
@@ -58,8 +59,9 @@ module Shoppe
     # All featured products
     scope :featured, -> {where(:featured => true)}
 
-    # All products ordered with default items first followed by name ascending
-    scope :ordered, -> {order(:default => :desc, :name => :asc)}
+    # Localisations
+    translates :name, :permalink, :description, :short_description
+    scope :ordered, -> { includes(:translations).order(:name) }
 
     # Return the name of the product
     #
@@ -81,6 +83,7 @@ module Shoppe
     #
     # @return [BigDecimal]
     def price
+      # self.default_variant ? self.default_variant.price : read_attribute(:price)
       self.default_variant ? self.default_variant.price : read_attribute(:price)
     end
 

--- a/app/models/shoppe/product/variants.rb
+++ b/app/models/shoppe/product/variants.rb
@@ -5,7 +5,7 @@ module Shoppe
     validate { errors.add :base, :can_belong_to_root if self.parent && self.parent.parent }
 
     # Variants of the product
-    has_many :variants, -> { order(:default => :desc, :name => :asc) }, :class_name => 'Shoppe::Product', :foreign_key => 'parent_id', :dependent => :destroy
+    has_many :variants, :class_name => 'Shoppe::Product', :foreign_key => 'parent_id', :dependent => :destroy
 
     # The parent product (only applies to variants)
     belongs_to :parent, :class_name => 'Shoppe::Product', :foreign_key => 'parent_id'

--- a/app/models/shoppe/product_category.rb
+++ b/app/models/shoppe/product_category.rb
@@ -23,14 +23,15 @@ module Shoppe
     validates :name, :presence => true
     validates :permalink, :presence => true, :uniqueness => {scope: :parent_id}, :permalink => true
 
-    # All categories ordered by their name ascending
-    scope :ordered, -> { order(:name) }
-
     # Root (no parent) product categories only
     scope :without_parent, -> { where(parent_id: nil) }
  
     # No descendents
     scope :except_descendants, ->(record) { where.not(id: (Array.new(record.descendants) << record).flatten) }
+
+    # Localisations
+    translates :name, :permalink, :description, :short_description
+    scope :ordered, -> { includes(:translations).order(:name) }
     
     # Set the permalink on callback
     before_validation :set_permalink, :set_ancestral_permalink

--- a/app/views/shoppe/product_categories/_form.html.haml
+++ b/app/views/shoppe/product_categories/_form.html.haml
@@ -48,4 +48,3 @@
     - unless @product_category.new_record?
       %span.right= link_to t('shoppe.delete') , @product_category, :class => 'button purple', :method => :delete, :data => {:confirm => t('shoppe.product_category.delete_confirmation') }
     = f.submit t('shoppe.submit'),  :class => 'button green'
-    = link_to t('shoppe.cancel') , :product_categories, :class => 'button'

--- a/app/views/shoppe/product_categories/edit.html.haml
+++ b/app/views/shoppe/product_categories/edit.html.haml
@@ -1,6 +1,8 @@
 - @page_title = t('shoppe.product_category.product_categories')
 = content_for :header do
-  %p.buttons= link_to t('shoppe.product_category.back_to_categories'), :product_categories, :class => 'button'
+  %p.buttons
+    = link_to t('shoppe.localisations.localisations') , [@product_category, :localisations], :class => 'button'
+    = link_to t('shoppe.product_category.back_to_categories'), :product_categories, :class => 'button'
   %h2.products= t('shoppe.product_category.product_categories')
 = render 'form'
 

--- a/app/views/shoppe/product_categories/index.html.haml
+++ b/app/views/shoppe/product_categories/index.html.haml
@@ -9,6 +9,7 @@
     %thead
       %tr
         %th= t('shoppe.product_category.name')
+        %th= t('shoppe.product_category.localisations')
     %tbody
       - if @product_categories_without_parent.empty?
         %tr.empty
@@ -17,4 +18,5 @@
         - for cat in @product_categories_without_parent
           %tr
             %td= link_to cat.name, [:edit, cat]
+            %td= link_to "Localisations", [cat, :localisations]
           = nested_product_category_rows(cat)

--- a/app/views/shoppe/product_categories/index.html.haml
+++ b/app/views/shoppe/product_categories/index.html.haml
@@ -9,7 +9,8 @@
     %thead
       %tr
         %th= t('shoppe.product_category.name')
-        %th= t('shoppe.product_category.localisations')
+        - I18n.available_locales.each do |i|
+          %th
     %tbody
       - if @product_categories_without_parent.empty?
         %tr.empty
@@ -18,5 +19,9 @@
         - for cat in @product_categories_without_parent
           %tr
             %td= link_to cat.name, [:edit, cat]
-            %td= link_to "Localisations", [cat, :localisations]
+            - I18n.available_locales.each do |i|
+              - if cat.translations.where(locale: i).count >= 1
+                %td= link_to i, edit_product_category_localisation_path(cat, cat.translations.where(locale: i).first.id)
+              - else
+                %td= link_to i, new_product_category_localisation_path(cat, locale_field: i)
           = nested_product_category_rows(cat)

--- a/app/views/shoppe/product_category_localisations/form.html.haml
+++ b/app/views/shoppe/product_category_localisations/form.html.haml
@@ -15,7 +15,7 @@
           %dd= f.text_field :name, :class => 'focus text'
         %dl.half
           %dt= f.label :locale
-          %dd= f.select :locale, I18n.available_locales, {selected: params[:locale_field]}, {class: "chosen"}
+          %dd= f.select :locale, I18n.available_locales, {selected: @localisation.locale || params[:locale_field]}, {class: "chosen"}
       %dl
         %dt= f.label :permalink, t('shoppe.product_category.permalink')
         %dd= f.text_field :permalink, :class => 'text'

--- a/app/views/shoppe/product_category_localisations/form.html.haml
+++ b/app/views/shoppe/product_category_localisations/form.html.haml
@@ -24,7 +24,6 @@
         %dd= f.text_area :description, :class => 'text'
 
     %p.submit
-      / - unless @localisation.new_record?
-      /   %span.right= link_to t('shoppe.delete'), product_category_localisation_path(@product_category, @localisation), :class => 'button purple', :method => :delete, :data => {:confirm => t('shoppe.products.delete_confirmation')}
+      - unless @localisation.new_record?
+        %span.right= link_to t('shoppe.delete'), product_category_localisation_path(@product_category, @localisation), :class => 'button purple', :method => :delete, :data => {:confirm => t('shoppe.localisations.delete_confirmation')}
       = f.submit t('shoppe.localisations.save_localisation'), :class => 'button green'
-      = link_to t('shoppe.cancel'), :product_categories, :class => 'button'

--- a/app/views/shoppe/product_category_localisations/form.html.haml
+++ b/app/views/shoppe/product_category_localisations/form.html.haml
@@ -1,0 +1,30 @@
+- @page_title = "#{t('shoppe.localisations.localisations')} - #{@product_category.name}"
+= content_for :header do
+  %p.buttons= link_to t('shoppe.localisations.back_to_localisations'), [@product_category, :localisations], :class => 'button'
+  %h2.products= t('shoppe.localisations.localisations_of', name: @product_category.name)
+
+- loc = @localisation.new_record? ? :en : @localisation.locale.to_sym
+- Globalize.with_locale(loc) do
+  = form_for [@product_category, @localisation], :url => @localisation.new_record? ? product_category_localisations_path(@product_category) : product_category_localisation_path(@product_category, @localisation), :html => {:multipart => true} do |f|
+    = f.error_messages
+
+    = field_set_tag t('shoppe.product_category.category_details') do
+      .splitContainer
+        %dl.half
+          %dt= f.label :name, t('shoppe.product_category.name')
+          %dd= f.text_field :name, :class => 'focus text'
+        %dl.half
+          %dt= f.label :locale
+          %dd= f.select :locale, I18n.available_locales, {}, {class: "chosen"}
+      %dl
+        %dt= f.label :permalink, t('shoppe.product_category.permalink')
+        %dd= f.text_field :permalink, :class => 'text'
+      %dl.cleared
+        %dt= f.label :description, t('shoppe.product_category.description')
+        %dd= f.text_area :description, :class => 'text'
+
+    %p.submit
+      / - unless @localisation.new_record?
+      /   %span.right= link_to t('shoppe.delete'), product_category_localisation_path(@product_category, @localisation), :class => 'button purple', :method => :delete, :data => {:confirm => t('shoppe.products.delete_confirmation')}
+      = f.submit t('shoppe.localisations.save_localisation'), :class => 'button green'
+      = link_to t('shoppe.cancel'), :product_categories, :class => 'button'

--- a/app/views/shoppe/product_category_localisations/form.html.haml
+++ b/app/views/shoppe/product_category_localisations/form.html.haml
@@ -15,7 +15,7 @@
           %dd= f.text_field :name, :class => 'focus text'
         %dl.half
           %dt= f.label :locale
-          %dd= f.select :locale, I18n.available_locales, {}, {class: "chosen"}
+          %dd= f.select :locale, I18n.available_locales, {selected: params[:locale_field]}, {class: "chosen"}
       %dl
         %dt= f.label :permalink, t('shoppe.product_category.permalink')
         %dd= f.text_field :permalink, :class => 'text'

--- a/app/views/shoppe/product_category_localisations/index.html.haml
+++ b/app/views/shoppe/product_category_localisations/index.html.haml
@@ -1,0 +1,26 @@
+- @page_title = "#{t('shoppe.localisations.localisations')} - #{@product_category.name}"
+
+= content_for :header do
+  %p.buttons
+    = link_to t('shoppe.localisations.back'), product_categories_path, :class => 'button'
+    = link_to t('shoppe.localisations.new_localisation'), [:new, @product_category, :localisation], :class => 'button green'
+
+  %h2.products= t('shoppe.localisations.localisations_of', name: @product_category.name)
+
+.table
+  %table.data
+    %thead
+      %tr
+        %th{:width => '20%'}= t('shoppe.localisations.language')
+        %th{:width => '50%'}= t('shoppe.products.name')
+        %th{:width => '15%'}= t('shoppe.products.permalink')
+    %tbody
+      - if @localisations.empty?
+        %tr.empty
+          %td{:colspan => 4}= t('shoppe.localisations.no_localisations')
+      - else
+        - for localisation in @localisations
+          %tr
+            %td= localisation.locale
+            %td= link_to localisation.name, edit_product_category_localisation_path(@product_category, localisation)
+            %td= localisation.permalink

--- a/app/views/shoppe/product_localisations/form.html.haml
+++ b/app/views/shoppe/product_localisations/form.html.haml
@@ -1,0 +1,33 @@
+- @page_title = "#{t('shoppe.localisations.localisations')} - #{@product.name}"
+= content_for :header do
+  %p.buttons= link_to t('shoppe.localisations.back_to_localisations'), [@product, :localisations], :class => 'button'
+  %h2.products= t('shoppe.localisations.localisations_of', name: @product.name)
+
+- loc = @localisation.new_record? ? :en : @localisation.locale.to_sym
+- Globalize.with_locale(loc) do
+  = form_for [@product, @localisation], :url => @localisation.new_record? ? product_localisations_path(@product) : product_localisation_path(@product, @localisation), :html => {:multipart => true} do |f|
+    = f.error_messages
+
+    = field_set_tag t('shoppe.product.category_details') do
+      .splitContainer
+        %dl.half
+          %dt= f.label :name, t('shoppe.product.name')
+          %dd= f.text_field :name, :class => 'focus text'
+        %dl.half
+          %dt= f.label :locale
+          %dd= f.select :locale, I18n.available_locales, {}, {class: "chosen"}
+      %dl
+        %dt= f.label :permalink, t('shoppe.product.permalink')
+        %dd= f.text_field :permalink, :class => 'text'
+      %dl.cleared
+        %dt= f.label :description, t('shoppe.product.description')
+        %dd= f.text_area :description, :class => 'text'
+      %dl.cleared
+        %dt= f.label :short_description, t('shoppe.product.short_description')
+        %dd= f.text_area :short_description, :class => 'text'
+
+    %p.submit
+      - unless @localisation.new_record?
+        %span.right= link_to t('shoppe.delete'), product_localisation_path(@product, @localisation), :class => 'button purple', :method => :delete, :data => {:confirm => t('shoppe.products.delete_confirmation')}
+      = f.submit t('shoppe.localisations.save_localisation'), :class => 'button green'
+      = link_to t('shoppe.cancel'), :product_categories, :class => 'button'

--- a/app/views/shoppe/product_localisations/form.html.haml
+++ b/app/views/shoppe/product_localisations/form.html.haml
@@ -28,6 +28,5 @@
 
     %p.submit
       - unless @localisation.new_record?
-        %span.right= link_to t('shoppe.delete'), product_localisation_path(@product, @localisation), :class => 'button purple', :method => :delete, :data => {:confirm => t('shoppe.products.delete_confirmation')}
+        %span.right= link_to t('shoppe.delete'), product_localisation_path(@product, @localisation), :class => 'button purple', :method => :delete, :data => {:confirm => t('shoppe.localisations.delete_confirmation')}
       = f.submit t('shoppe.localisations.save_localisation'), :class => 'button green'
-      = link_to t('shoppe.cancel'), :product_categories, :class => 'button'

--- a/app/views/shoppe/product_localisations/index.html.haml
+++ b/app/views/shoppe/product_localisations/index.html.haml
@@ -2,7 +2,7 @@
 
 = content_for :header do
   %p.buttons
-    = link_to t('shoppe.localisations.back'), product_categories_path, :class => 'button'
+    = link_to t('shoppe.localisations.back'), [:edit, @product], :class => 'button'
     = link_to t('shoppe.localisations.new_localisation'), [:new, @product, :localisation], :class => 'button green'
 
   %h2.products= t('shoppe.localisations.localisations_of', name: @product.name)

--- a/app/views/shoppe/product_localisations/index.html.haml
+++ b/app/views/shoppe/product_localisations/index.html.haml
@@ -1,0 +1,26 @@
+- @page_title = "#{t('shoppe.localisations.localisations')} - #{@product.name}"
+
+= content_for :header do
+  %p.buttons
+    = link_to t('shoppe.localisations.back'), product_categories_path, :class => 'button'
+    = link_to t('shoppe.localisations.new_localisation'), [:new, @product, :localisation], :class => 'button green'
+
+  %h2.products= t('shoppe.localisations.localisations_of', name: @product.name)
+
+.table
+  %table.data
+    %thead
+      %tr
+        %th{:width => '20%'}= t('shoppe.localisations.language')
+        %th{:width => '50%'}= t('shoppe.products.name')
+        %th{:width => '15%'}= t('shoppe.products.permalink')
+    %tbody
+      - if @localisations.empty?
+        %tr.empty
+          %td{:colspan => 4}= t('shoppe.localisations.no_localisations')
+      - else
+        - for localisation in @localisations
+          %tr
+            %td= localisation.locale
+            %td= link_to localisation.name, edit_product_localisation_path(@product, localisation)
+            %td= localisation.permalink

--- a/app/views/shoppe/products/edit.html.haml
+++ b/app/views/shoppe/products/edit.html.haml
@@ -1,6 +1,7 @@
 - @page_title = t('shoppe.products.products')
 = content_for :header do
   %p.buttons
+    = link_to t('shoppe.localisations.localisations') , [@product, :localisations], :class => 'button'
     = link_to t('shoppe.products.variants') , [@product, :variants], :class => 'button'
     = link_to t('shoppe.products.stock_levels') , stock_level_adjustments_path(:item_id => @product.id, :item_type => @product.class), :class => 'button', :rel => 'dialog', :data => {:dialog_width => 700, :dialog_behavior => 'stockLevelAdjustments'}
     = link_to t('shoppe.products.back_to_products') , :products, :class => 'button'

--- a/app/views/shoppe/variants/form.html.haml
+++ b/app/views/shoppe/variants/form.html.haml
@@ -1,6 +1,8 @@
 - @page_title = "#{t('shoppe.variants.variants')} - #{@product.name}"
 = content_for :header do
-  %p.buttons= link_to t('shoppe.variants.back_to_variants'), [@product, :variants], :class => 'button'
+  %p.buttons
+    = link_to t('shoppe.localisations.localisations') , [@variant, :localisations], :class => 'button'
+    = link_to t('shoppe.variants.back_to_variants'), [@product, :variants], :class => 'button'
   %h2.products= t('shoppe.variants.variants_of', product:@product.name)
 
 = form_for [@product, @variant], :url => @variant.new_record? ? product_variants_path(@product) : product_variant_path(@product, @variant), :html => {:multipart => true} do |f|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -611,8 +611,10 @@ en:
       edit_localisation: Edit Localisation
       localisation_created: Localisation created successfully
       localisation_updated: Localisation updated successfully
+      localisation_destroyed: Localisation destroyed successfully
       language: Language
       no_localisations: No localisations to display.
+      delete_confirmation: Are you sure?
 
     navigation:
       admin_primary:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -598,6 +598,22 @@ en:
       destroy_notice: Payment has been removed successfully
       refund_notice: Refund has been processed successfully.
 
+    localisations:
+      localisations: Localisations
+      back: Back
+      back_to_localisations: Back
+      localisations_of: Localisations of %{name}
+      product_information: Product Information
+      locales: Locales
+      choose_locale: Please choose a locale
+      save_localisation: Save Localisation
+      new_localisation: New Localisation
+      edit_localisation: Edit Localisation
+      localisation_created: Localisation created successfully
+      localisation_updated: Localisation updated successfully
+      language: Language
+      no_localisations: No localisations to display.
+
     navigation:
       admin_primary:
         orders: Orders

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,12 @@
 Shoppe::Engine.routes.draw do
 
   get 'attachment/:id/:filename.:extension' => 'attachments#show'
-  resources :product_categories
+  resources :product_categories do
+    resources :localisations, controller: "product_category_localisations"
+  end
   resources :products do
     resources :variants
+    resources :localisations, controller: "product_localisations"
     collection do
       get :import
       post :import

--- a/db/migrate/20150513171350_create_shoppe_product_category_translation_table.rb
+++ b/db/migrate/20150513171350_create_shoppe_product_category_translation_table.rb
@@ -1,6 +1,15 @@
 class CreateShoppeProductCategoryTranslationTable < ActiveRecord::Migration
   def up
     Shoppe::ProductCategory.create_translation_table! :name => :string, :permalink => :string, :description => :text
+
+    Shoppe::ProductCategory.all.each do |pc|
+      l = pc.translations.new
+      l.locale = "en"
+      l.name = pc.name
+      l.permalink = pc.permalink
+      l.description = pc.description
+      l.save!
+    end
   end
   def down
     Shoppe::ProductCategory.drop_translation_table!

--- a/db/migrate/20150513171350_create_shoppe_product_category_translation_table.rb
+++ b/db/migrate/20150513171350_create_shoppe_product_category_translation_table.rb
@@ -1,0 +1,8 @@
+class CreateShoppeProductCategoryTranslationTable < ActiveRecord::Migration
+  def up
+    Shoppe::ProductCategory.create_translation_table! :name => :string, :permalink => :string, :description => :text
+  end
+  def down
+    Shoppe::ProductCategory.drop_translation_table!
+  end
+end

--- a/db/migrate/20150519173350_create_shoppe_product_translation_table.rb
+++ b/db/migrate/20150519173350_create_shoppe_product_translation_table.rb
@@ -1,6 +1,16 @@
 class CreateShoppeProductTranslationTable < ActiveRecord::Migration
   def up
     Shoppe::Product.create_translation_table! :name => :string, :permalink => :string, :description => :text, :short_description => :text
+
+    Shoppe::Product.all.each do |p|
+      l = p.translations.new
+      l.locale = "en"
+      l.name = p.name
+      l.permalink = p.permalink
+      l.description = p.description
+      l.short_description = p.short_description
+      l.save!
+    end
   end
   def down
     Shoppe::Product.drop_translation_table!

--- a/db/migrate/20150519173350_create_shoppe_product_translation_table.rb
+++ b/db/migrate/20150519173350_create_shoppe_product_translation_table.rb
@@ -1,0 +1,8 @@
+class CreateShoppeProductTranslationTable < ActiveRecord::Migration
+  def up
+    Shoppe::Product.create_translation_table! :name => :string, :permalink => :string, :description => :text, :short_description => :text
+  end
+  def down
+    Shoppe::Product.drop_translation_table!
+  end
+end

--- a/lib/shoppe.rb
+++ b/lib/shoppe.rb
@@ -6,6 +6,7 @@ require 'bcrypt'
 require 'dynamic_form'
 require 'kaminari'
 require 'ransack'
+require "globalize"
 
 require 'nifty/utils'
 require 'nifty/key_value_store'

--- a/shoppe.gemspec
+++ b/shoppe.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", ">= 3", "< 4.1"
   s.add_dependency "roo", ">= 1.13.0", "< 1.14"
   s.add_dependency "awesome_nested_set", "~> 3.0.1"
+  s.add_dependency "globalize"
 
   s.add_dependency "nifty-key-value-store", ">= 1.0.1", "< 2.0.0"
   s.add_dependency "nifty-utils", ">= 1.0", "< 1.1"


### PR DESCRIPTION
Some ecommerce sites may have different languages (e.g. en, de, fr, es). This update adds the Globalize gem and the code needed to add localisations.

This may break current shops if the following commands aren't run. I have only tested it on a local shop for a client and it works well.

Once adding the changes, you'll need to migrate the database to add the translation tables and run these in the rails console to create english product categories & products

```ruby
Shoppe::ProductCategory.all.each do |pc|
  l = pc.translations.new
  l.locale = "en"
  l.name = pc.name
  l.permalink = pc.permalink
  l.description = pc.description
  l.save!
end

Shoppe::Product.all.each do |p|
  l = p.translations.new
  l.locale = "en"
  l.name = p.name
  l.permalink = p.permalink
  l.description = p.description
  l.short_description = p.short_description
  l.save!
end
```