### PR TITLE
Add missing de-translations that caused error "must add at least one product category" 

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -387,6 +387,7 @@ de:
       attachments: Anhänge
       back_to_categories: Zurück zu den Kategorien
       category_details: Kategoriedetails
+      choose_product_category: Produktkategorie auswählen
       create_notice: Kategorie wurde erfolgreich erstellt
       delete_confirmation: Möchten Sie diese Kategorie wirklich löschen?
       description: Beschreibung
@@ -601,6 +602,7 @@ de:
         users: Benutzer
         countries: Länder
         settings: Einstellungen
+        customers: Kunden
 
     settings:
 


### PR DESCRIPTION
The missing translation leads to an incorrect rendering of the ```select box``` with id ```product_product_category_ids```.
## Incorrect Output
```
<select class="chosen" multiple="multiple" data-placeholder="<span class=" translation_missing"="" title="translation missing: de.shoppe.product_category.choose_product_category" style="display: none;">Choose Product Category" name="product[product_category_ids][]" id="product_product_category_ids"&gt;
    <option value="1">Option1</option>
    <option value="4">Option2</option>
    <option value="5">...</option>
</select>
```       
Hence, you are not able to create a product because the transfered parameter ```product_category_ids=>[""]``` doesn't contain any values although you have selected options from the select box.

By adding the appropriate translation, the following output will be generated ...
## Correct output
```
<select class="chosen" multiple="multiple" data-placeholder="Produktkategorie auswählen" name="product[product_category_ids][]" id="product_product_category_ids" style="display: none;">    
    <option value="1">Option1</option>
    <option value="4">Option2</option>
    <option value="5">...</option>
</select>
```
Now the selected options are passed to the controller in the correct way.