### PR TITLE
Permalink as default param for products and categories

### DIFF
--- a/app/controllers/shoppe/product_categories_controller.rb
+++ b/app/controllers/shoppe/product_categories_controller.rb
@@ -2,7 +2,7 @@ module Shoppe
   class ProductCategoriesController < Shoppe::ApplicationController
 
     before_filter { @active_nav = :product_categories }
-    before_filter { params[:id] && @product_category = Shoppe::ProductCategory.find(params[:id]) }
+    before_filter { params[:id] && @product_category = Shoppe::ProductCategory.find_by(permalink: params[:id]) }
 
     def index
       @product_categories_without_parent = Shoppe::ProductCategory.without_parent.ordered

--- a/app/controllers/shoppe/product_category_localisations_controller.rb
+++ b/app/controllers/shoppe/product_category_localisations_controller.rb
@@ -4,7 +4,7 @@ module Shoppe
   class ProductCategoryLocalisationsController < ApplicationController
 
     before_filter { @active_nav = :product_categories }
-    before_filter { @product_category = Shoppe::ProductCategory.find(params[:product_category_id]) }
+    before_filter { @product_category = Shoppe::ProductCategory.find_by(permalink: params[:product_category_id]) }
     before_filter { params[:id] && @localisation = @product_category.translations.find(params[:id]) }
 
     def index

--- a/app/controllers/shoppe/product_localisations_controller.rb
+++ b/app/controllers/shoppe/product_localisations_controller.rb
@@ -4,7 +4,7 @@ module Shoppe
   class ProductLocalisationsController < ApplicationController
 
     before_filter { @active_nav = :products }
-    before_filter { @product = Shoppe::Product.find(params[:product_id]) }
+    before_filter { @product = Shoppe::Product.find_by(permalink: params[:product_id]) }
     before_filter { params[:id] && @localisation = @product.translations.find(params[:id]) }
 
     def index

--- a/app/controllers/shoppe/products_controller.rb
+++ b/app/controllers/shoppe/products_controller.rb
@@ -2,7 +2,7 @@ module Shoppe
   class ProductsController < Shoppe::ApplicationController
 
     before_filter { @active_nav = :products }
-    before_filter { params[:id] && @product = Shoppe::Product.root.find(params[:id]) }
+    before_filter { params[:id] && @product = Shoppe::Product.root.find_by(permalink: params[:id]) }
 
     def index
       @products = Shoppe::Product.root.includes(:translations, :stock_level_adjustments, :default_image, :product_categories, :variants).order(:name).group_by(&:product_category).sort_by { |cat,pro| cat.name }

--- a/app/controllers/shoppe/variants_controller.rb
+++ b/app/controllers/shoppe/variants_controller.rb
@@ -2,7 +2,7 @@ module Shoppe
   class VariantsController < ApplicationController
 
     before_filter { @active_nav = :products }
-    before_filter { @product = Shoppe::Product.find(params[:product_id]) }
+    before_filter { @product = Shoppe::Product.find_by(permalink: params[:product_id]) }
     before_filter { params[:id] && @variant = @product.variants.find(params[:id]) }
 
     def index

--- a/app/models/shoppe/product.rb
+++ b/app/models/shoppe/product.rb
@@ -108,6 +108,10 @@ module Shoppe
       self.product_categories.first rescue nil
     end
 
+    def to_param
+      permalink
+    end
+
     # Search for products which include the given attributes and return an active record
     # scope of these products. Chainable with other scopes and with_attributes methods.
     # For example:

--- a/app/models/shoppe/product.rb
+++ b/app/models/shoppe/product.rb
@@ -60,7 +60,7 @@ module Shoppe
     scope :featured, -> {where(:featured => true)}
 
     # Localisations
-    translates :name, :permalink, :description, :short_description
+    translates :name, :description, :short_description
     scope :ordered, -> { includes(:translations).order(:name) }
 
     # Return the name of the product

--- a/app/models/shoppe/product_category.rb
+++ b/app/models/shoppe/product_category.rb
@@ -51,6 +51,10 @@ module Shoppe
       parent.hierarchy_array.concat [self]
     end
 
+    def to_param
+      permalink
+    end
+
     private
 
     def set_permalink

--- a/app/models/shoppe/product_category.rb
+++ b/app/models/shoppe/product_category.rb
@@ -29,7 +29,7 @@ module Shoppe
     # No descendents
     scope :except_descendants, ->(record) { where.not(id: (Array.new(record.descendants) << record).flatten) }
 
-    translates :name, :permalink, :description, :short_description
+    translates :name, :description, :short_description
     scope :ordered, -> { includes(:translations).order(:name) }
     
     # Set the permalink on callback

--- a/shoppe.gemspec
+++ b/shoppe.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", ">= 3", "< 4.1"
   s.add_dependency "roo", ">= 1.13.0", "< 1.14"
   s.add_dependency "awesome_nested_set", "~> 3.0.1"
-  s.add_dependency "globalize", "~> 5.0.0"
+  s.add_dependency "globalize",  "5.0.1"
 
   s.add_dependency "nifty-key-value-store", ">= 1.0.1", "< 2.0.0"
   s.add_dependency "nifty-utils", ">= 1.0", "< 1.1"

--- a/shoppe.gemspec
+++ b/shoppe.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", ">= 3", "< 4.1"
   s.add_dependency "roo", ">= 1.13.0", "< 1.14"
   s.add_dependency "awesome_nested_set", "~> 3.0.1"
-  s.add_dependency "globalize"
+  s.add_dependency "globalize", "~> 5.0.0"
 
   s.add_dependency "nifty-key-value-store", ">= 1.0.1", "< 2.0.0"
   s.add_dependency "nifty-utils", ">= 1.0", "< 1.1"


### PR DESCRIPTION
Use the permalink as the default URL parameter for products and categories.
This should be the default behavior because it's the most common scenario. Shoppe's documentation suggests using the permalink as well.
This breaks sites that don't already use the permalink.