### PR TITLE
Add missing Portuguese translation

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -604,6 +604,7 @@ pt-BR:
         users: Usuários
         countries: Países
         settings: Preferências
+        customers: Clientes
 
     settings:
 


### PR DESCRIPTION
Add translation for *customers* in Portuguese.

When the word customers was shown in the admin panel, this error would be shown: 

`translation missing: pt-BR.shoppe.navigation.admin_primary.customers`