### PR TITLE
Added missing translation that didn't let categories be saved when in spanish

### DIFF
--- a/config/locales/es-US.yml
+++ b/config/locales/es-US.yml
@@ -387,6 +387,7 @@ es-US:
       attachments: Adjuntos
       back_to_categories: Volver a la lista de categorías
       category_details: Detalles de categoría
+      choose_product_category: Escoje categoría del producto
       create_notice: Categoría creada satisfactoriamente
       delete_confirmation:  ¿ Está seguro que desea remover esta categoría ?
       description: Descripción

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,4 @@
-es-US:
+es:
   activerecord:
     models:
       shoppe/country:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,4 @@
-es:
+es-US:
   activerecord:
     models:
       shoppe/country:
@@ -387,6 +387,7 @@ es:
       attachments: Adjuntos
       back_to_categories: Volver a la lista de categorías
       category_details: Detalles de categoría
+      choose_product_category: Escoje categoría del producto
       create_notice: Categoría creada satisfactoriamente
       delete_confirmation:  ¿ Está seguro que desea remover esta categoría ?
       description: Descripción


### PR DESCRIPTION
This bug wasn't letting the administrator save categories or products because of the missing translation when selecting a category and trying to save it said, "please select a category" even when you selected it.

With this fix, it should no longer be a problem.