### PR TITLE
remove storage line in attachment_uploader.rb file

### DIFF
--- a/app/uploaders/shoppe/attachment_uploader.rb
+++ b/app/uploaders/shoppe/attachment_uploader.rb
@@ -4,7 +4,6 @@ class Shoppe::AttachmentUploader < CarrierWave::Uploader::Base
 
   include CarrierWave::MiniMagick
 
-  storage :file
 
   # Where should files be stored?
   def store_dir


### PR DESCRIPTION
When this line is present is imposible to modified the storage option of carrierwave from the initializer, so its necessary to remove it so that it can be change to use `:fog` instead of `:file`