### PR TITLE
Adjust regex for phone number

### DIFF
--- a/app/models/shoppe/customer.rb
+++ b/app/models/shoppe/customer.rb
@@ -9,7 +9,7 @@ module Shoppe
 
     # Validations
     validates :email, :presence => true, :uniqueness => true, :format => {:with => /\A\b[A-Z0-9\.\_\%\-\+]+@(?:[A-Z0-9\-]+\.)+[A-Z]{2,6}\b\z/i}
-    validates :phone, :presence => true, :format => {:with => /\A[\d\ \-x\(\)]{7,}\z/}
+    validates :phone, :presence => true, :format => {:with => /\A[+?\d\ \-x\(\)]{7,}\z/}
 
     # All customers ordered by their ID desending
     scope :ordered, -> { order(:id => :desc)}

--- a/app/models/shoppe/order.rb
+++ b/app/models/shoppe/order.rb
@@ -27,7 +27,7 @@ module Shoppe
     validates :token, :presence => true
     with_options :if => Proc.new { |o| !o.building? } do |order|
       order.validates :email_address, :format => {:with => /\A\b[A-Z0-9\.\_\%\-\+]+@(?:[A-Z0-9\-]+\.)+[A-Z]{2,6}\b\z/i}
-      order.validates :phone_number, :format => {:with => /\A[\d\ \-x\(\)]{7,}\z/}
+      order.validates :phone_number, :format => {:with => /\A[+?\d\ \-x\(\)]{7,}\z/}
     end
 
     # Set some defaults


### PR DESCRIPTION
At the moment Shoppe rejects phone numbers, when they start with a + character which is a valid part of a phone number. E.g. +41 79 123 45 67 is a valid phone number over here in Switzerland. The regex should be adjusted to allow the + sign in the beginning.