### PR TITLE
Missing 'track' in shipped email template

### DIFF
--- a/app/views/shoppe/order_mailer/shipped.text.erb
+++ b/app/views/shoppe/order_mailer/shipped.text.erb
@@ -6,7 +6,7 @@ We're pleased to let you know your order has been shipped and
 will be with you shortly!
 
 <% if @order.delivery_service && @order.courier_tracking_url -%>
-You can the delivery online at:
+You can track the delivery online at:
 <%=@order.courier_tracking_url%>
 <% end -%>
 


### PR DESCRIPTION
Looks like you missed a word here.