### PR TITLE
Ensure delivery_service_price takes the country into account

### DIFF
--- a/app/models/shoppe/order/delivery.rb
+++ b/app/models/shoppe/order/delivery.rb
@@ -156,7 +156,7 @@ module Shoppe
     #
     # @return [BigDecimal]
     def delivery_service_price
-      self.delivery_service && self.delivery_service.delivery_service_prices.for_weight(self.total_weight).first
+      self.delivery_service && delivery_service_prices.select{ |price| price.delivery_service == delivery_service }.first
     end
 
     # The price for delivering this order in its current state


### PR DESCRIPTION
Currently, when an order gets its applicable `delivery_service_price`, it only ensures the one returned is associated with the correct `delivery_service` and that it can handle the weight. It doesn't consider the orders' country or whether the price is the cheapest available.

This PR fixes the above by using the `Order#delivery_service_prices` method, and returning the first applicable price.

