### PR TITLE
Address es.yml and en.yml

### DIFF
--- a/app/views/shoppe/addresses/_form.html.haml
+++ b/app/views/shoppe/addresses/_form.html.haml
@@ -1,7 +1,7 @@
 = form_for @address, url: [@customer, @address] do |f|
   = f.error_messages
 
-  = field_set_tag t('shope.addresses.address_information') do
+  = field_set_tag t('shoppe.addresses.address_information') do
     %dl
       %dt= f.label :address_type
       %dd= f.select :address_type, Shoppe::Address::TYPES, {}, class: 'chosen'

--- a/app/views/shoppe/addresses/_form.html.haml
+++ b/app/views/shoppe/addresses/_form.html.haml
@@ -1,7 +1,7 @@
 = form_for @address, url: [@customer, @address] do |f|
   = f.error_messages
 
-  = field_set_tag 'Address Information' do
+  = field_set_tag t('shope.addresses.address_information') do
     %dl
       %dt= f.label :address_type
       %dd= f.select :address_type, Shoppe::Address::TYPES, {}, class: 'chosen'

--- a/app/views/shoppe/addresses/edit.html.haml
+++ b/app/views/shoppe/addresses/edit.html.haml
@@ -1,5 +1,5 @@
 - @page_title = 'Edit Address'
 = content_for :header do
-  %p.buttons= link_to 'Back to customer', @customer, :class => 'button'
-  %h2.users Edit Address
+  %p.buttons= link_to t('shoppe.addresses.back_to_customer'), @customer, :class => 'button'
+  %h2.users t('shoppe.addresses.addresses')
 = render 'form'

--- a/app/views/shoppe/addresses/new.html.haml
+++ b/app/views/shoppe/addresses/new.html.haml
@@ -1,5 +1,5 @@
 - @page_title = "New Address for #{@customer.name}"
 = content_for :header do
   %p.buttons= link_to 'Back to customer', @customer, class: 'button'
-  %h2.users= t('shoppe.address.address')
+  %h2.users t('shoppe.products.products')
 = render 'form'

--- a/app/views/shoppe/addresses/new.html.haml
+++ b/app/views/shoppe/addresses/new.html.haml
@@ -1,5 +1,5 @@
 - @page_title = "New Address for #{@customer.name}"
 = content_for :header do
-  %p.buttons= link_to 'Back to customer', @customer, class: 'button'
-  %h2.users t('shoppe.products.products')
+  %p.buttons= link_to t('shoppe.products.products'), @customer, class: 'button'
+  %h2.users= t('shoppe.addresses.addresses')
 = render 'form'

--- a/app/views/shoppe/addresses/new.html.haml
+++ b/app/views/shoppe/addresses/new.html.haml
@@ -1,5 +1,5 @@
 - @page_title = "New Address for #{@customer.name}"
 = content_for :header do
-  %p.buttons= link_to t('shoppe.products.products'), @customer, class: 'button'
+  %p.buttons= link_to t('shoppe.addresses.back_to_customer'), @customer, class: 'button'
   %h2.users= t('shoppe.addresses.addresses')
 = render 'form'

--- a/app/views/shoppe/addresses/new.html.haml
+++ b/app/views/shoppe/addresses/new.html.haml
@@ -1,5 +1,5 @@
 - @page_title = "New Address for #{@customer.name}"
 = content_for :header do
   %p.buttons= link_to 'Back to customer', @customer, class: 'button'
-  %h2.users New Address
+  %h2.users= t('shoppe.address.address')
 = render 'form'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -732,6 +732,8 @@ en:
       deleted_successfully: Customer has been deleted successfully.
 
     addresses:
+      address_information: Address Information
+      back_to_customer: Back customer
       addresses: New Address
       created_successfully: Address has been created successfully.
       updated_successfully: Address has been updated successfully.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,9 @@
 en:
   activerecord:
     models:
+      shoppe/address:
+        one: Address
+        other: Addresses
       shoppe/country:
         one: Country
         other: Countries
@@ -42,6 +45,14 @@ en:
         other: Users
 
     attributes:
+      shoppe/address:
+        address_type: Address type
+        address1: Address 1
+        address2: Address 3
+        address3: Address 3
+        address4: Address 4
+        postcode: Postcode
+        country: Country
       shoppe/order:
         billing_address1: Billing address1
         billing_address3: Billing address3
@@ -721,6 +732,7 @@ en:
       deleted_successfully: Customer has been deleted successfully.
 
     addresses:
+      addresses: New Address
       created_successfully: Address has been created successfully.
       updated_successfully: Address has been updated successfully.
       deleted_successfully: Address has been deleted successfully.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -132,13 +132,13 @@ es:
       models:
         shoppe/address:
           attributes:
-            adress1:
+            address1:
               blank: se encuentra en blanco.
-            adress2:
+            address2:
               blank: se encuentra en blanco.
-            adress3:
+            address3:
               blank: se encuentra en blanco.
-            adress4:
+            address4:
               blank: se encuentra en blanco.
             postcode:
               blank: se encuentra en blanco.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -518,6 +518,10 @@ es:
       website_properties: Propiedades del sitio web
       weight: Peso
 
+      filter:
+        sku: filtro por prudcto sku
+        name_or_description: filtro por nombre de producto o descripción
+
       imports:
         help: Productos y categorías son identificados por nombre. Si no se encuentra ningún producto coincidente se creará uno nuevo con todos los atributos de la línea. Si se encuentra un producto coincidente, solo se actualizará la cantidad y se ignorarán todos los demás campos. Si no se encuentra ninguna categoría coincidente, se creará una con el mismo nombre. Un producto por línea. Puede dejar el campo del enlace permanente en blanco si prefiere que se genere automáticamente.
         success: Productos importados correctamente

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -754,6 +754,7 @@ es:
       deleted_successfully: Cliente ha sido eliminado exitosamente.
 
     addresses:
+      back_to_customer: Volver al cliente
       addresses: Nueva Dirección
       created_successfully: Dirección ha sido creada exitosamente.
       updated_successfully: Dirección ha sido actualizada exitosamente.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -691,7 +691,7 @@ es:
       new_customer: Nuevo cliente
       search_customer: Buscar cliente
       name: Nombre
-      company Compañía
+      company: Compañía
       email: E-Mail
       phone: Teléfono
       mobile_phone: Teléfono movil

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -167,6 +167,10 @@ es:
               must_be_specified: Debe ser especificado
         shoppe/product:
           attributes:
+            description:
+              blank: no puede estar en blanco
+            short_description: 
+              blank: no puede estar en blanco
             permalink:
               wrong_format: "solo puede contener letras, números, - y _"
             base:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -122,11 +122,11 @@ es:
         shoppe/customer:
           attributes:
             email:
-              blank: E-mail se encuentra en blanco.
-              invalid: E-mail es inválido.
+              blank: se encuentra en blanco.
+              invalid: es inválido.
             phone:
-              blank: Teléfono se encuentra en blanco.
-              invalid: Teléfono es inválido.
+              blank: se encuentra en blanco.
+              invalid: es inválido.
         shoppe/product_category:
           attributes:
             permalink:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -754,6 +754,7 @@ es:
       deleted_successfully: Cliente ha sido eliminado exitosamente.
 
     addresses:
+      address_information: Información de Dirección
       back_to_customer: Volver al cliente
       addresses: Nueva Dirección
       created_successfully: Dirección ha sido creada exitosamente.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,6 +1,9 @@
 es:
   activerecord:
     models:
+      shoppe/address:
+        one: Dirección
+        other: Direcciones
       shoppe/country:
         one: País
         other: Países
@@ -42,6 +45,14 @@ es:
         other: Usuarios
 
     attributes:
+      shoppe/address:
+        address_type: Tipo de dirección
+        address1: Dirección 1
+        address2: Dirección 3
+        address3: Dirección 3
+        address4: Dirección 4
+        postcode: Código postal
+        country: País
       shoppe/order:
         billing_address1: Dirección de facturación 1
         billing_address3: Dirección de facturación 3
@@ -119,6 +130,20 @@ es:
           many: ! '%{count} errores han impedido completar el guardado'
           other: ! '%{count} errors han impedido completar el guardado'
       models:
+        shoppe/address:
+          attributes:
+            adress1:
+              blank: se encuentra en blanco.
+            adress2:
+              blank: se encuentra en blanco.
+            adress3:
+              blank: se encuentra en blanco.
+            adress4:
+              blank: se encuentra en blanco.
+            postcode:
+              blank: se encuentra en blanco.
+            country:
+              blank: se encuentra en blanco.
         shoppe/customer:
           attributes:
             email:
@@ -729,6 +754,7 @@ es:
       deleted_successfully: Cliente ha sido eliminado exitosamente.
 
     addresses:
+      addresses: Nueva Dirección
       created_successfully: Dirección ha sido creada exitosamente.
       updated_successfully: Dirección ha sido actualizada exitosamente.
       deleted_successfully: Dirección ha sido eliminada exitosamente.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -686,10 +686,44 @@ es:
       no_localisations: Ninguna traducción a mostrar.
       delete_confirmation: ¿Seguro?
 
+    customers:
+      customers: Clientes
+      new_customer: Nuevo cliente
+      search_customer: Buscar cliente
+      name: Nombre
+      company Compañía
+      email: E-Mail
+      phone: Teléfono
+      mobile_phone: Teléfono movil
+      no_customers: Sin clientes para mostrar.
+      search: Buscar
+      first_or_last_name: Primer o segundo nombre:
+      back_to_customers_list: Volver a lista de clientes.
+      new_address: Nueva dirección
+      edit: Editar
+      customer_information: Información de Cliente
+      cancel: Cancelar
+      first_name: Primer nombre
+      last_name: Segundo nombre
+      delete: Eliminar
+      save: Guardar
+      creating_customer: Creando Cliente...
+      updating_customer: Actualizando Cliente...
+      delete_confirmation: ¿Estas seguro que deseas eliminar este cliente?
+      type: Tipo
+      default: Por defecto
+      address: Dirección
+      no_addresses: Sin dirección para mostrar
+      addresses: Direcciones
+      adresse: Dirección
+      created_successfully: Cliente ha sido creado exitosamente.
+      updated_successfully: Cliente ha sido actualizado exitosamente.
+      deleted_successfully: Cliente ha sido eliminado exitosamente.
+
     addresses:
-      created_successfully: Address has been created successfully.
-      updated_successfully: Address has been updated successfully.
-      deleted_successfully: Address has been deleted successfully.
+      created_successfully: Dirección ha sido creada exitosamente.
+      updated_successfully: Dirección ha sido actualizada exitosamente.
+      deleted_successfully: Dirección ha sido eliminada exitosamente.
 
     navigation:
       admin_primary:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -826,3 +826,9 @@ es:
         goto: Ir
         logged_in_as: "Accediendo como %{user_name}"
         logout: Salir
+
+  time:
+    formats:
+      default: "%Y/%m/%d"
+      short: "%b %d"
+      long: "%B %d, %Y"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -119,6 +119,14 @@ es:
           many: ! '%{count} errores han impedido completar el guardado'
           other: ! '%{count} errors han impedido completar el guardado'
       models:
+        shoppe/customer:
+          attributes:
+            email:
+              blank: E-mail se encuentra en blanco.
+              invalid: E-mail es inválido.
+            phone:
+              blank: Teléfono se encuentra en blanco.
+              invalid: Teléfono es inválido.
         shoppe/product_category:
           attributes:
             permalink:
@@ -697,14 +705,14 @@ es:
       mobile_phone: Teléfono movil
       no_customers: Sin clientes para mostrar.
       search: Buscar
-      first_or_last_name: Primer o segundo nombre.
+      first_or_last_name: Primer nombre o apellido.
       back_to_customers_list: Volver a lista de clientes.
       new_address: Nueva dirección
       edit: Editar
       customer_information: Información de Cliente
       cancel: Cancelar
       first_name: Primer nombre
-      last_name: Segundo nombre
+      last_name: Apellido
       delete: Eliminar
       save: Guardar
       creating_customer: Creando Cliente...

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -697,7 +697,7 @@ es:
       mobile_phone: Teléfono movil
       no_customers: Sin clientes para mostrar.
       search: Buscar
-      first_or_last_name: Primer o segundo nombre:
+      first_or_last_name: Primer o segundo nombre.
       back_to_customers_list: Volver a lista de clientes.
       new_address: Nueva dirección
       edit: Editar


### PR DESCRIPTION
Guys,

I added to es.yml and en.yml missed locals for spanish.

Can you merge in actual version ?.

Also I detected a error, but I dont know where puts this text in en.yml and en.yml

```
I18n::MissingTranslationData in Shoppe::StockLevelAdjustments#index

Showing /home/smok/.rvm/gems/ruby-2.2.1/bundler/gems/shoppe-a0beed1c4505/app/views/shoppe/stock_level_adjustments
/index.html.haml where line #36 raised:
translation missing: es.time.formats.long
```

thank you!