### PR TITLE
Removed billing_address

### DIFF
--- a/app/models/shoppe/order/billing.rb
+++ b/app/models/shoppe/order/billing.rb
@@ -13,8 +13,6 @@ module Shoppe
       order.validates :first_name, presence: true
       order.validates :last_name, presence: true
       order.validates :billing_address1, presence: true
-      order.validates :billing_address3, presence: true
-      order.validates :billing_address4, presence: true
       order.validates :billing_postcode, presence: true
       order.validates :billing_country, presence: true
     end


### PR DESCRIPTION
I've removed validations for billing_address 3 and 4. Now the method proceed_to_confirm works with only one address. 

